### PR TITLE
Add linting to browserify bundler

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -41,11 +41,13 @@ var config = {
   // Predefined browserify configs to keep tasks DRY
   browserify: {
     dragular: {
+      type: 'dragular',
       entryPoint: './src/dragularModule.js',
       bundleName: 'dragular.js',
       dest: './dist',
     },
     docs: {
+      type: 'docs',
       entryPoint: './docs/src/examples/examplesApp.js',
       bundleName: 'examples.js',
       dest: './docs/dist'
@@ -90,7 +92,7 @@ function buildScript() {
   if (!config.isProd) {
     bundler = watchify(bundler);
     bundler.on('update', function() {
-      rebundle();
+      lintAndRebundle();
     });
   }
 
@@ -106,8 +108,6 @@ function buildScript() {
       .pipe(source(browserifyDefaults.bundleName))
       .pipe(buffer())
       .pipe(gulpif(config.isProd, sourcemaps.init({loadMaps: true})))
-      .pipe(jshint())
-      .pipe(jshint.reporter('jshint-stylish'))
       .pipe(gulpif(config.isProd, uglify({
         compress: { drop_console: true }
       })))
@@ -122,7 +122,15 @@ function buildScript() {
       .pipe(browserSync.stream());
   }
 
-  return rebundle();
+  function lintAndRebundle() {
+    if (browserifyDefaults.type === 'dragular') {
+      return sequence('lint', rebundle);
+    }
+
+    return sequence('lint:docs', rebundle);
+  }
+
+  return lintAndRebundle();
 }
 
 gulp.task('browserify', function() {
@@ -249,7 +257,6 @@ gulp.task('build:docs', function() {
   config.isProd = true;
   browserifyDefaults = config.browserify.docs;
 
-  config.isProd = true;
   sequence(['browserify', 'styles']);
 });
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -106,6 +106,8 @@ function buildScript() {
       .pipe(source(browserifyDefaults.bundleName))
       .pipe(buffer())
       .pipe(gulpif(config.isProd, sourcemaps.init({loadMaps: true})))
+      .pipe(jshint())
+      .pipe(jshint.reporter('jshint-stylish'))
       .pipe(gulpif(config.isProd, uglify({
         compress: { drop_console: true }
       })))


### PR DESCRIPTION
I kept `gulp lint` and `gulp lint:docs` tasks in case if there would be a need to lint files manually