### PR TITLE
Add markdown to html compilation task

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,10 +1,10 @@
-#How to contribute
+# How to contribute
 
 It's important to us that you feel you can contribute towards the evolution of Dragular. This can take many forms: from helping to fix bugs or improve the docs, to adding in new features to the source. This guide should help you in making that process as smooth as possible.
 
 Before contributing, please read the [code of conduct](https://github.com/luckylooke/dragular/blob/master/CODE_OF_CONDUCT.md).
 
-##Reporting issues
+## Reporting issues
 
 [GitHub Issues][0] is the place to report bugs you may have found in either the core library or any of the examples that are part of the repository. When submitting a bug please do the following:
 
@@ -18,12 +18,12 @@ Before contributing, please read the [code of conduct](https://github.com/luckyl
 
 **5. Share as much information as possible.** Include browser version affected, your OS, version of the library, steps to reproduce, etc. "X isn't working!!!1!" will probably just be closed.
 
-##Dev vs. Master
+## Dev vs. Master
 
 The dev branch of Dragular is our 'current working' version. It is always ahead of the master branch in terms of features and fixes. However it's also bleeding-edge and experimental and we cannot and do not guarantee it will compile or work for you. Very often we have to break things for a few days while we rebuild and patch. So by all means please export the dev branch and contribute towards it, indeed that is where all Pull Requests should be sent, but do so understanding the API may change beneath you.
 
 
-##Making Changes
+## Making Changes
 
 To take advantage of our npm build script and jshint config it will be easiest for you if you have node.js installed locally.
 
@@ -31,7 +31,7 @@ You can download node.js from [nodejs.org][3].
 
 After that you can clone the repository and run `npm i` inside the cloned folder. This will install dependencies necessary for building the project. For development workflow automation dragular uses `gulp >= 3.9.0`. Before starting development, make sure that `gulp` is installed on your machine globally: `npm i -g gulp`.
 
-###Developing
+### Developing
 
 There are several gulp tasks that are used for generating different builds:
 
@@ -40,11 +40,11 @@ There are several gulp tasks that are used for generating different builds:
 - `gulp build` - Concatenates and minifies dragular source files.
 - `gulp build:docs` - Concatenates and minifies documentation source files.
 
-###Linting
+### Linting
 
 - `gulp lint` & `gulp lint:docs` - Lint JavaScript files.
 
-###Making a pull request
+### Making a pull request
 
 Once that is ready, make your changes and submit a Pull Request:
 
@@ -58,12 +58,12 @@ Once that is ready, make your changes and submit a Pull Request:
 Dependencies for building from source and running tests:
 
 
-##Coding style preferences are not contributions
+## Coding style preferences are not contributions
 
 If your PR is doing little more than changing the Dragular source code into a format / coding style that you prefer then we will automatically close it. All PRs must adhere to the coding style already set-out across the lines of code in Dragular. Your personal preferences for how things should "look" or be structured do not apply here, sorry. PRs should fix bugs, fix documentation or add features. No changes for the sake of change.
 
 
-##I don't really like git / node.js, but I can fix this bug
+## I don't really like git / node.js, but I can fix this bug
 
 That is fine too. While Pull Requests are the best thing in the world for us, they are not the only way to help. You're welcome to post fixes to our forum or even just email them to us. All we ask is that you still adhere to the guidelines presented here re: JSHint, etc.
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -193,7 +193,7 @@ gulp.task('serve', function () {
 * Concatenate and register templates in the $templateCache. The resulting file
 * (templates.js) is placed inside the directory specified in config.docs.src.
 */
-gulp.task('templates:docs', ['markdown'], function() {
+gulp.task('templates:docs', function() {
 
   return gulp.src(config.docs.templates)
     .pipe(templateCache({
@@ -214,6 +214,7 @@ gulp.task('watch:docs', ['serve'], function() {
   gulp.watch(config.docs.styles,  ['styles:docs']);
   gulp.watch(config.docs.templates,  ['templates:docs']);
   gulp.watch(config.docs.index, browserSync.reload);
+  gulp.watch(['./CONTRIBUTING.md', './readme.markdown'], ['markdown']);
 });
 
 /*
@@ -231,7 +232,7 @@ gulp.task('dev:docs', function() {
   config.isProd = false;
   browserifyDefaults = config.browserify.docs;
 
-  sequence('templates:docs', ['browserify', 'styles:docs'], 'watch:docs');
+  sequence('markdown', 'templates:docs', ['browserify', 'styles:docs'], 'watch:docs');
 });
 
 /*
@@ -248,8 +249,7 @@ gulp.task('build:docs', function() {
   config.isProd = true;
   browserifyDefaults = config.browserify.docs;
 
-  config.isProd = true;
-  sequence(['browserify', 'styles']);
+  sequence('markdown', 'templates:docs', ['browserify', 'styles']);
 });
 
 /*
@@ -264,6 +264,7 @@ gulp.task('deploy:docs', function() {
 * Compiles markdown to html.
 */
 gulp.task('markdown', function () {
+
   return gulp.src(['./CONTRIBUTING.md', './readme.markdown'])
     .pipe(markdown())
     .pipe(gulpif('**/CONTRIBUTING.html', rename({basename: 'partial-contribute'})))

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -19,6 +19,7 @@ var concat = require('gulp-concat');
 var ngAnnotate = require('browserify-ngannotate');
 var templateCache = require('gulp-angular-templatecache');
 var ghPages = require('gulp-gh-pages');
+var markdown = require('gulp-markdown');
 
 var config = {
   dragular: {
@@ -192,7 +193,7 @@ gulp.task('serve', function () {
 * Concatenate and register templates in the $templateCache. The resulting file
 * (templates.js) is placed inside the directory specified in config.docs.src.
 */
-gulp.task('templates:docs', function() {
+gulp.task('templates:docs', ['markdown'], function() {
 
   return gulp.src(config.docs.templates)
     .pipe(templateCache({
@@ -230,7 +231,7 @@ gulp.task('dev:docs', function() {
   config.isProd = false;
   browserifyDefaults = config.browserify.docs;
 
-  sequence(['templates:docs'], ['browserify', 'styles:docs'], 'watch:docs');
+  sequence('templates:docs', ['browserify', 'styles:docs'], 'watch:docs');
 });
 
 /*
@@ -257,4 +258,15 @@ gulp.task('build:docs', function() {
 gulp.task('deploy:docs', function() {
   return gulp.src('./docs/**/*')
     .pipe(ghPages());
+});
+
+/*
+* Compiles markdown to html.
+*/
+gulp.task('markdown', function () {
+  return gulp.src(['./CONTRIBUTING.md', './readme.markdown'])
+    .pipe(markdown())
+    .pipe(gulpif('**/CONTRIBUTING.html', rename({basename: 'partial-contribute'})))
+    .pipe(gulpif('**/readme.html', rename({ basename: 'partial-readme'})))
+    .pipe(gulp.dest(config.docs.src + '/partials'));
 });

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "gulp-gh-pages": "^0.5.2",
     "gulp-if": "^1.2.5",
     "gulp-jshint": "^1.11.2",
+    "gulp-markdown": "^1.0.0",
     "gulp-minify-css": "^1.2.0",
     "gulp-rename": "^1.2.2",
     "gulp-size": "^1.2.3",


### PR DESCRIPTION
Hey!
I added `gulp markdown` task that compiles `CONTRIBUTING.md` and `readme.markdown` to `docs/src/examples/partials/partial-contribute.html` and `docs/src/examples/partials/partial-readme.html`. I also added these `.md` files to the watch task: every time when it's changed, it's compiled to html and added to angular template cache. 