### PR TITLE
Deploy:docs config bugfix

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -77,7 +77,7 @@ function buildScript() {
 
   var bundler = browserify({
     entries: browserifyDefaults.entryPoint,
-    debug: true,
+    debug: false,
     cache: {},
     packageCache: {},
     fullPaths: false


### PR DESCRIPTION
> When opts.debug is true, add a source map inline to the end of the bundle. This makes debugging easier because you can see all the original files if you are in a modern enough browser.

I found that issue was caused by browserify `debug` option. The path was [encoded with base64](https://github.com/luckylooke/dragular/blob/master/docs/dist/examples.js#L1856), that's why it was hard to find it.
Could you add `.publish/` to `.gitignore`? It's just a local `gulp-gh-pages` cache.