### PR TITLE
Fix: css property typo

### DIFF
--- a/dist/dragular.css
+++ b/dist/dragular.css
@@ -1,7 +1,7 @@
 .gu-mirror {
   position: fixed !important;
   margin: 0 !important;
-  width: z-index 9999 !important;
+  z-index 9999 !important;
   opacity: 0.8;
 }
 


### PR DESCRIPTION
It seems a typo was introducted on this css property.

I didn't generate the minified version. I'm glad to do it if you can show me how, or it wouldn't bother me if you just go ahead and fix that yourself.