### PR TITLE
Send target index on dragulardrop event

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "gulp-sourcemaps": "^1.5.2",
     "gulp-uglify": "^1.2.0",
     "gulp-util": "^3.0.6",
+    "jshint-stylish": "^2.1.0",
     "run-sequence": "^1.1.2",
     "vinyl-buffer": "^1.0.0",
     "vinyl-source-stream": "^1.1.0",

--- a/src/dragularService.js
+++ b/src/dragularService.js
@@ -448,19 +448,20 @@ dragularModule.factory('dragularService', ['$rootScope', function dragula($rootS
           item.parentElement.removeChild(shared.sourceItem);
         }
 
+        var dropIndex = domIndexOf(item, target);
+
         function emitDropEvent() {
           if (o.scope) {
             if (isInitialPlacement(target)) {
               o.scope.$emit('dragularcancel', item, shared.source, shared.sourceModel, shared.initialIndex);
             } else {
-              o.scope.$emit('dragulardrop', item, target, shared.source, shared.sourceModel, shared.initialIndex, shared.targetModel);
+              o.scope.$emit('dragulardrop', item, target, shared.source, shared.sourceModel, shared.initialIndex, shared.targetModel, dropIndex);
             }
           }
         }
 
         if (shared.sourceModel && !isInitialPlacement(target)) {
-          var dropElm = item,
-            dropIndex = domIndexOf(dropElm, target);
+          var dropElm = item;
           $rootScope.$applyAsync(function applyDrop() {
             if (target === shared.source) {
               shared.sourceModel.splice(dropIndex, 0, shared.sourceModel.splice(shared.initialIndex, 1)[0]);


### PR DESCRIPTION
Hi, thanks for building dragular !

I'm using it in a work project and need to know the target **index** at which the currently dragged item was dropped on the `dragulardrop` event. I need to know it to properly call REST routes to update our backend when dropping things, and it can get tricky to recompute it on my own with the info provided.

I also included a second commit to add `jshint-stylish` as dev dependency. It seems to be used in `gulp lint` and caused errors in the task when I first checked out the repo.

I did not include generated filed (`dist/` and `docs/`) in the commit, I don't know how you usually deal with these things, I can amend to add them.

On a side note, I was slightly confused by the `gulp dev` task. Does it build `dragular.js` and then include it in the docs we see with browsersync ? It didn't seem to be the case as I could not see my new argument in the Events part of the docs.

Thanks in advance, I hope we can merge this soon :).