### PR TITLE
Update handle comparison for Dragular

### DIFF
--- a/docs/src/examples/exampleHandle/exampleHandle.js
+++ b/docs/src/examples/exampleHandle/exampleHandle.js
@@ -4,7 +4,7 @@ var HandleCtrl = function ($element, dragularService) {
   dragularService.cleanEnviroment();
 	dragularService($element.children(), {
     moves: function(el, container, handle) {
-      return handle.className === 'handle';
+      return handle.classList.contains('handle');
     }
   });
 };


### PR DESCRIPTION
In reality we usually may use other classes  with 'handle' classes. So it is better to compare with contains than equal.