### PR TITLE
Fix for broken Angular dependency semver

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   },
   "homepage": "http://luckylooke.github.io/dragular/",
   "dependencies": {
-    "angular": "~1.4.0"
+    "angular": "^1.4.0"
   },
   "devDependencies": {
     "browser-sync": "^2.8.0",


### PR DESCRIPTION
Fixed error in package.json angular dependency semver which was forcing angular 1.4 installation